### PR TITLE
[DROOLS-4349] Implement liveness and readiness probes + fix potential deadlock during on-demand snapshot

### DIFF
--- a/hacep/src/main/java/org/kie/hacep/Config.java
+++ b/hacep/src/main/java/org/kie/hacep/Config.java
@@ -48,6 +48,8 @@ public class Config {
     public static final String SKIP_ON_DEMAND_SNAPSHOT = "skip.ondemandsnapshoot";
     public static final String TEST = Boolean.FALSE.toString();
     public static final String UNDER_TEST = "undertest";
+    public static final String MAX_SNAPSHOT_REQUEST_ATTEMPTS = "max.snapshot.request.attempts";
+    public static final String DEFAULT_MAX_SNAPSHOT_REQUEST_ATTEMPTS = "10";
     private static final Logger logger = LoggerFactory.getLogger(Config.class);
     private static Properties config;
     private static Properties consumerConf, producerConf, snapshotConsumerConf, snapshotProducerConf;

--- a/hacep/src/main/java/org/kie/hacep/EnvConfig.java
+++ b/hacep/src/main/java/org/kie/hacep/EnvConfig.java
@@ -30,6 +30,7 @@ public final class EnvConfig {
     private String printerType;
     private int iterationBetweenSnapshot = Config.DEFAULT_ITERATION_BETWEEN_SNAPSHOT;
     private int pollTimeout = 1000;
+    private int maxSnapshotRequestAttempts = 10;
     private boolean skipOnDemanSnapshot;
     private long maxSnapshotAge;
     private boolean test;
@@ -50,6 +51,7 @@ public final class EnvConfig {
                 skipOnDemandSnapshot(Optional.ofNullable(System.getenv(Config.SKIP_ON_DEMAND_SNAPSHOT)).orElse(Boolean.FALSE.toString())).
                 withIterationBetweenSnapshot(Optional.ofNullable(System.getenv(Config.ITERATION_BETWEEN_SNAPSHOT)).orElse(String.valueOf(Config.DEFAULT_ITERATION_BETWEEN_SNAPSHOT))).
                 withMaxSnapshotAgeSeconds(Optional.ofNullable(System.getenv(Config.MAX_SNAPSHOT_AGE)).orElse(Config.DEFAULT_MAX_SNAPSHOT_AGE_SEC)).
+                withMaxSnapshotRequestAttempts(Optional.ofNullable(System.getenv(Config.MAX_SNAPSHOT_REQUEST_ATTEMPTS)).orElse(Config.DEFAULT_MAX_SNAPSHOT_REQUEST_ATTEMPTS)).
                 underTest(Optional.ofNullable(System.getenv(Config.UNDER_TEST)).orElse(Config.TEST));
     }
 
@@ -121,6 +123,11 @@ public final class EnvConfig {
         return this;
     }
 
+    public EnvConfig withMaxSnapshotRequestAttempts(String maxSnapshotRequestAttempts) {
+        this.maxSnapshotRequestAttempts = Integer.parseInt(maxSnapshotRequestAttempts);
+        return this;
+    }
+
     public EnvConfig clone() {
         EnvConfig envConfig = new EnvConfig();
         envConfig.eventsTopicName = this.eventsTopicName;
@@ -135,6 +142,7 @@ public final class EnvConfig {
         envConfig.iterationBetweenSnapshot = this.iterationBetweenSnapshot;
         envConfig.skipOnDemanSnapshot = this.skipOnDemanSnapshot;
         envConfig.maxSnapshotAge = this.maxSnapshotAge;
+        envConfig.maxSnapshotRequestAttempts = this.maxSnapshotRequestAttempts;
         return envConfig;
     }
 
@@ -186,6 +194,10 @@ public final class EnvConfig {
         return local;
     }
 
+    public int getMaxSnapshotRequestAttempts() {
+        return maxSnapshotRequestAttempts;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("EnvConfig{");
@@ -199,6 +211,7 @@ public final class EnvConfig {
         sb.append(", iterationBetweenSnapshot='").append(iterationBetweenSnapshot).append('\'');
         sb.append(", skipOnDemanSnapshot='").append(skipOnDemanSnapshot).append('\'');
         sb.append(", maxSnapshotAge='").append(maxSnapshotAge).append('\'');
+        sb.append(", maxSnapshotRequestAttempts='").append(maxSnapshotRequestAttempts).append('\'');
         sb.append(", underTest='").append(test).append('\'');
         sb.append('}');
         return sb.toString();

--- a/hacep/src/main/java/org/kie/hacep/consumer/DroolsConsumerHandler.java
+++ b/hacep/src/main/java/org/kie/hacep/consumer/DroolsConsumerHandler.java
@@ -134,7 +134,7 @@ public class DroolsConsumerHandler implements ConsumerHandler {
             try {
                 visitable.accept(commandHandler);
             } catch (Throwable e) {
-                GlobalStatus.nodeLive.set(false);
+                GlobalStatus.nodeLive = false;
                 throw e;
             }
         }

--- a/hacep/src/main/java/org/kie/hacep/consumer/DroolsConsumerHandler.java
+++ b/hacep/src/main/java/org/kie/hacep/consumer/DroolsConsumerHandler.java
@@ -20,6 +20,7 @@ import java.util.Queue;
 import org.kie.api.KieServices;
 import org.kie.api.runtime.KieContainer;
 import org.kie.hacep.EnvConfig;
+import org.kie.hacep.core.GlobalStatus;
 import org.kie.hacep.core.KieSessionContext;
 import org.kie.hacep.core.infra.DeafultSessionSnapShooter;
 import org.kie.hacep.core.infra.SnapshotInfos;
@@ -130,7 +131,12 @@ public class DroolsConsumerHandler implements ConsumerHandler {
         boolean execute = state.equals(State.LEADER) || command.isPermittedForReplicas();
         if (execute) {
             VisitableCommand visitable = (VisitableCommand) command;
-            visitable.accept(commandHandler);
+            try {
+                visitable.accept(commandHandler);
+            } catch (Throwable e) {
+                GlobalStatus.nodeLive.set(false);
+                throw e;
+            }
         }
     }
 

--- a/hacep/src/main/java/org/kie/hacep/core/Bootstrap.java
+++ b/hacep/src/main/java/org/kie/hacep/core/Bootstrap.java
@@ -16,6 +16,7 @@
 package org.kie.hacep.core;
 
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.kie.hacep.Config;
 import org.kie.hacep.EnvConfig;
@@ -30,6 +31,7 @@ import org.slf4j.LoggerFactory;
  */
 public class Bootstrap {
 
+    public static AtomicBoolean readyToGo = new AtomicBoolean(false);
     private static final Logger logger = LoggerFactory.getLogger(Bootstrap.class);
     private static Producer eventProducer;
     private static ConsumerController consumerController;

--- a/hacep/src/main/java/org/kie/hacep/core/Bootstrap.java
+++ b/hacep/src/main/java/org/kie/hacep/core/Bootstrap.java
@@ -44,7 +44,7 @@ public class Bootstrap {
         if(!envConfig.isUnderTest()) {
             leaderElection();
         }
-        GlobalStatus.nodeReady.set(true);
+        GlobalStatus.nodeReady = true;
         logger.info("CONFIGURE on start engine:{}", envConfig);
     }
 

--- a/hacep/src/main/java/org/kie/hacep/core/Bootstrap.java
+++ b/hacep/src/main/java/org/kie/hacep/core/Bootstrap.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
  */
 public class Bootstrap {
 
-    public static AtomicBoolean readyToGo = new AtomicBoolean(false);
     private static final Logger logger = LoggerFactory.getLogger(Bootstrap.class);
     private static Producer eventProducer;
     private static ConsumerController consumerController;
@@ -45,6 +44,7 @@ public class Bootstrap {
         if(!envConfig.isUnderTest()) {
             leaderElection();
         }
+        GlobalStatus.nodeReady.set(true);
         logger.info("CONFIGURE on start engine:{}", envConfig);
     }
 

--- a/hacep/src/main/java/org/kie/hacep/core/GlobalStatus.java
+++ b/hacep/src/main/java/org/kie/hacep/core/GlobalStatus.java
@@ -15,14 +15,12 @@
  */
 package org.kie.hacep.core;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 /**
  * Shared global status
  */
 public class GlobalStatus {
 
-    public static final AtomicBoolean nodeReady = new AtomicBoolean(false);
-    public static final AtomicBoolean nodeLive = new AtomicBoolean(true);
-    public static final AtomicBoolean canBecomeLeader = new AtomicBoolean(true);
+    public static volatile boolean nodeReady = false;
+    public static volatile boolean nodeLive = true;
+    public static volatile boolean canBecomeLeader = true;
 }

--- a/hacep/src/main/java/org/kie/hacep/core/GlobalStatus.java
+++ b/hacep/src/main/java/org/kie/hacep/core/GlobalStatus.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class GlobalStatus {
 
-    public static AtomicBoolean nodeReady = new AtomicBoolean(false);
-    public static AtomicBoolean nodeLive = new AtomicBoolean(true);
-    public static AtomicBoolean canBecomeLeader = new AtomicBoolean(true);
+    public static final AtomicBoolean nodeReady = new AtomicBoolean(false);
+    public static final AtomicBoolean nodeLive = new AtomicBoolean(true);
+    public static final AtomicBoolean canBecomeLeader = new AtomicBoolean(true);
 }

--- a/hacep/src/main/java/org/kie/hacep/core/GlobalStatus.java
+++ b/hacep/src/main/java/org/kie/hacep/core/GlobalStatus.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.hacep.core;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Shared global status
+ */
+public class GlobalStatus {
+
+    public static AtomicBoolean nodeReady = new AtomicBoolean(false);
+    public static AtomicBoolean nodeLive = new AtomicBoolean(true);
+    public static AtomicBoolean canBecomeLeader = new AtomicBoolean(true);
+}

--- a/hacep/src/main/java/org/kie/hacep/core/infra/consumer/DefaultKafkaConsumer.java
+++ b/hacep/src/main/java/org/kie/hacep/core/infra/consumer/DefaultKafkaConsumer.java
@@ -145,7 +145,6 @@ public class DefaultKafkaConsumer<T> implements EventConsumer {
         if (!completed) {
             throw new RuntimeException("Can't obtain a snapshot on demand");
         }
-        Bootstrap.readyToGo.set(true);
     }
 
     private void assign(List partitions) {

--- a/hacep/src/main/java/org/kie/hacep/core/infra/consumer/DefaultKafkaConsumer.java
+++ b/hacep/src/main/java/org/kie/hacep/core/infra/consumer/DefaultKafkaConsumer.java
@@ -35,6 +35,7 @@ import org.apache.kafka.common.errors.WakeupException;
 import org.kie.hacep.Config;
 import org.kie.hacep.EnvConfig;
 import org.kie.hacep.consumer.DroolsConsumerHandler;
+import org.kie.hacep.core.Bootstrap;
 import org.kie.hacep.core.infra.DeafultSessionSnapShooter;
 import org.kie.hacep.core.infra.OffsetManager;
 import org.kie.hacep.core.infra.SnapshotInfos;
@@ -144,6 +145,7 @@ public class DefaultKafkaConsumer<T> implements EventConsumer {
         if (!completed) {
             throw new RuntimeException("Can't obtain a snapshot on demand");
         }
+        Bootstrap.readyToGo.set(true);
     }
 
     private void assign(List partitions) {

--- a/hacep/src/main/java/org/kie/hacep/core/infra/consumer/DefaultKafkaConsumer.java
+++ b/hacep/src/main/java/org/kie/hacep/core/infra/consumer/DefaultKafkaConsumer.java
@@ -463,8 +463,8 @@ public class DefaultKafkaConsumer<T> implements EventConsumer {
                                     currentState);
             saveOffset(record,
                        kafkaConsumer);
-            if (logger.isInfoEnabled()) {
-                logger.info("change topic, switch to consume control");
+            if (logger.isDebugEnabled()) {
+                logger.debug("change topic, switch to consume control");
             }
         } else if (processingReplica) {
             consumerHandler.process(ItemToProcess.getItemToProcess(record),

--- a/hacep/src/main/java/org/kie/hacep/core/infra/election/LeaderElectionImpl.java
+++ b/hacep/src/main/java/org/kie/hacep/core/infra/election/LeaderElectionImpl.java
@@ -134,7 +134,7 @@ public class LeaderElectionImpl implements LeaderElection {
                                 logPrefix());
                 }
             }
-        } else if (!GlobalStatus.canBecomeLeader.get()) {
+        } else if (!GlobalStatus.canBecomeLeader) {
             // Node is waiting for an initial state to use as starting point
             logger.info("{} Pod is not initialized yet (waiting snapshot) so cannot try to become leader",
                         logPrefix());

--- a/hacep/src/main/java/org/kie/hacep/core/infra/election/LeaderElectionImpl.java
+++ b/hacep/src/main/java/org/kie/hacep/core/infra/election/LeaderElectionImpl.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import org.kie.hacep.core.Bootstrap;
+import org.kie.hacep.core.GlobalStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -126,7 +126,6 @@ public class LeaderElectionImpl implements LeaderElection {
                                 logPrefix());
                 }
                 this.currentState = State.LEADER;
-                Bootstrap.readyToGo.set(true);
                 this.serializedExecutor.execute(this::refreshStatus);
                 return;
             } else {
@@ -135,7 +134,7 @@ public class LeaderElectionImpl implements LeaderElection {
                                 logPrefix());
                 }
             }
-        } else if (!Bootstrap.readyToGo.get()) {
+        } else if (!GlobalStatus.canBecomeLeader.get()) {
             // Node is waiting for an initial state to use as starting point
             logger.info("{} Pod is not initialized yet (waiting snapshot) so cannot try to become leader",
                         logPrefix());

--- a/hacep/src/main/java/org/kie/hacep/core/infra/utils/SnapshotOnDemandUtils.java
+++ b/hacep/src/main/java/org/kie/hacep/core/infra/utils/SnapshotOnDemandUtils.java
@@ -113,7 +113,7 @@ public class SnapshotOnDemandUtils {
         boolean snapshotReady = false;
         SnapshotMessage msg = null;
         try {
-            GlobalStatus.canBecomeLeader.set(false);
+            GlobalStatus.canBecomeLeader = false;
             int counter = 0;
             while (!snapshotReady) {
                 ConsumerRecords<String, byte[]> records = consumer.poll(Duration.of(Integer.valueOf(Config.DEFAULT_POLL_TIMEOUT_MS),
@@ -131,7 +131,7 @@ public class SnapshotOnDemandUtils {
                     // use a counter to avoid infinite attempts
                     counter += 1;
                     if(counter > envConfig.getMaxSnapshotRequestAttempts()) {
-                        GlobalStatus.nodeLive.set(false);
+                        GlobalStatus.nodeLive = false;
                         String errorMessage = "Impossible to retrieve a snapshot and start after " + counter + " attempts";
                         logger.error(errorMessage);
                         throw new IllegalStateException(errorMessage);
@@ -140,7 +140,7 @@ public class SnapshotOnDemandUtils {
             }
         } finally {
             consumer.close();
-            GlobalStatus.canBecomeLeader.set(true);
+            GlobalStatus.canBecomeLeader = true;
         }
         return msg;
     }

--- a/hacep/src/main/java/org/kie/hacep/core/infra/utils/SnapshotOnDemandUtils.java
+++ b/hacep/src/main/java/org/kie/hacep/core/infra/utils/SnapshotOnDemandUtils.java
@@ -37,6 +37,7 @@ import org.kie.api.runtime.KieSessionConfiguration;
 import org.kie.api.runtime.conf.ClockTypeOption;
 import org.kie.hacep.Config;
 import org.kie.hacep.EnvConfig;
+import org.kie.hacep.core.GlobalStatus;
 import org.kie.hacep.core.infra.SessionSnapshooter;
 import org.kie.hacep.core.infra.SnapshotInfos;
 import org.kie.hacep.message.SnapshotMessage;
@@ -112,6 +113,7 @@ public class SnapshotOnDemandUtils {
         boolean snapshotReady = false;
         SnapshotMessage msg = null;
         try {
+            GlobalStatus.canBecomeLeader.set(false);
             while (!snapshotReady) {
                 ConsumerRecords<String, byte[]> records = consumer.poll(Duration.of(Integer.valueOf(Config.DEFAULT_POLL_TIMEOUT_MS),
                                                                                     ChronoUnit.MILLIS));
@@ -127,6 +129,7 @@ public class SnapshotOnDemandUtils {
             }
         } finally {
             consumer.close();
+            GlobalStatus.canBecomeLeader.set(true);
         }
         return msg;
     }

--- a/jdkhttp/kubernetes/deployment.yaml
+++ b/jdkhttp/kubernetes/deployment.yaml
@@ -26,7 +26,7 @@ spec:
             exec:
               command:
                 - curl
-                - localhost:8080/health
+                - localhost:8080/liveness
             initialDelaySeconds: 20
             periodSeconds: 10
             timeoutSeconds: 1
@@ -38,7 +38,7 @@ spec:
             exec:
               command:
                 - curl
-                - localhost:8080/health
+                - localhost:8080/readiness
             initialDelaySeconds: 10
             periodSeconds: 5
             timeoutSeconds: 1

--- a/jdkhttp/kubernetes/deployment_registry.yaml
+++ b/jdkhttp/kubernetes/deployment_registry.yaml
@@ -26,7 +26,7 @@ spec:
             exec:
               command:
                 - curl
-                - localhost:8080/health
+                - localhost:8080/liveness
             initialDelaySeconds: 20
             periodSeconds: 10
             timeoutSeconds: 1
@@ -38,7 +38,7 @@ spec:
             exec:
               command:
                 - curl
-                - localhost:8080/health
+                - localhost:8080/readiness
             initialDelaySeconds: 10
             periodSeconds: 5
             timeoutSeconds: 1

--- a/jdkhttp/src/main/java/org/kie/hacep/endpoint/bootstrap/JdkHttpServer.java
+++ b/jdkhttp/src/main/java/org/kie/hacep/endpoint/bootstrap/JdkHttpServer.java
@@ -51,7 +51,7 @@ public class JdkHttpServer {
 
         @Override
         public void handle(HttpExchange httpExchange) throws IOException {
-            initResponse(httpExchange, GlobalStatus.nodeReady.get());
+            initResponse(httpExchange, GlobalStatus.nodeReady);
         }
     }
 
@@ -59,7 +59,7 @@ public class JdkHttpServer {
 
         @Override
         public void handle(HttpExchange httpExchange) throws IOException {
-            initResponse(httpExchange, GlobalStatus.nodeLive.get());
+            initResponse(httpExchange, GlobalStatus.nodeLive);
         }
     }
 

--- a/jdkhttp/src/main/java/org/kie/hacep/endpoint/bootstrap/JdkHttpServer.java
+++ b/jdkhttp/src/main/java/org/kie/hacep/endpoint/bootstrap/JdkHttpServer.java
@@ -25,34 +25,52 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import org.kie.hacep.EnvConfig;
 import org.kie.hacep.core.Bootstrap;
+import org.kie.hacep.core.GlobalStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class JdkHttpServer {
 
     private final static String OK = "OK";
+    private final static String KO = "KO";
     private static Logger logger = LoggerFactory.getLogger(JdkHttpServer.class);
 
     public static void main(String[] args) throws Exception {
 
         HttpServer server = HttpServer.create(new InetSocketAddress(8080), 0);
-        server.createContext("/health", new HealthHandler());
+        server.createContext("/readiness", new ReadinessHandler());
+        server.createContext("/liveness", new LivenessHandler());
         server.createContext("/env/all", new EnvHandler());
         server.start();
         Bootstrap.startEngine(EnvConfig.getDefaultEnvConfig());
         logger.info("Core system started");
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> Bootstrap.stopEngine()));
+        Runtime.getRuntime().addShutdownHook(new Thread(Bootstrap::stopEngine));
     }
 
-    static class HealthHandler implements HttpHandler {
+    static class ReadinessHandler implements HttpHandler {
 
         @Override
         public void handle(HttpExchange httpExchange) throws IOException {
-            httpExchange.sendResponseHeaders(200, OK.length());
-            OutputStream os = httpExchange.getResponseBody();
-            os.write(OK.getBytes());
-            os.close();
+            initResponse(httpExchange, GlobalStatus.nodeReady.get());
         }
+    }
+
+    static class LivenessHandler implements HttpHandler {
+
+        @Override
+        public void handle(HttpExchange httpExchange) throws IOException {
+            initResponse(httpExchange, GlobalStatus.nodeLive.get());
+        }
+    }
+
+    private static void initResponse(HttpExchange httpExchange, boolean isOk) throws IOException {
+        int returnCode = isOk ? 200 : 400;
+        int returnLength = isOk ? OK.length() : KO.length();
+        byte[] returnBytes = isOk ? OK.getBytes() : KO.getBytes();
+        httpExchange.sendResponseHeaders(returnCode, returnLength);
+        OutputStream os = httpExchange.getResponseBody();
+        os.write(returnBytes);
+        os.close();
     }
 
     private static class EnvHandler implements HttpHandler {

--- a/springboot/kubernetes/deployment.yaml
+++ b/springboot/kubernetes/deployment.yaml
@@ -26,7 +26,7 @@ spec:
             exec:
               command:
                 - curl
-                - localhost:8080/health
+                - localhost:8080/liveness
             initialDelaySeconds: 20
             periodSeconds: 10
             timeoutSeconds: 1
@@ -38,7 +38,7 @@ spec:
             exec:
               command:
                 - curl
-                - localhost:8080/health
+                - localhost:8080/readiness
             initialDelaySeconds: 10
             periodSeconds: 5
             timeoutSeconds: 1

--- a/springboot/kubernetes/deployment_registry.yaml
+++ b/springboot/kubernetes/deployment_registry.yaml
@@ -26,7 +26,7 @@ spec:
             exec:
               command:
                 - curl
-                - localhost:8080/health
+                - localhost:8080/liveness
             initialDelaySeconds: 20
             periodSeconds: 10
             timeoutSeconds: 1
@@ -38,7 +38,7 @@ spec:
             exec:
               command:
                 - curl
-                - localhost:8080/health
+                - localhost:8080/readiness
             initialDelaySeconds: 10
             periodSeconds: 5
             timeoutSeconds: 1

--- a/springboot/src/main/java/org/kie/hacep/endpoint/Endpoints.java
+++ b/springboot/src/main/java/org/kie/hacep/endpoint/Endpoints.java
@@ -38,7 +38,7 @@ public class Endpoints {
 
     @GetMapping("/readiness")
     public ResponseEntity<Void> getReadiness() {
-        if(GlobalStatus.nodeReady.get()) {
+        if(GlobalStatus.nodeReady) {
             return ResponseEntity.status(HttpStatus.OK).build();
         } else {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
@@ -47,7 +47,7 @@ public class Endpoints {
 
     @GetMapping("/liveness")
     public ResponseEntity<Void> getLiveness() {
-        if(GlobalStatus.nodeLive.get()) {
+        if(GlobalStatus.nodeLive) {
             return ResponseEntity.status(HttpStatus.OK).build();
         } else {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();

--- a/springboot/src/main/java/org/kie/hacep/endpoint/Endpoints.java
+++ b/springboot/src/main/java/org/kie/hacep/endpoint/Endpoints.java
@@ -17,6 +17,7 @@ package org.kie.hacep.endpoint;
 
 import java.util.Map;
 
+import org.kie.hacep.core.GlobalStatus;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,8 +36,21 @@ public class Endpoints {
         return ResponseEntity.status(HttpStatus.OK).body(sb.toString());
     }
 
-    @GetMapping("/health")
-    public ResponseEntity<Void> check() {
-        return ResponseEntity.status(HttpStatus.OK).build();
+    @GetMapping("/readiness")
+    public ResponseEntity<Void> getReadiness() {
+        if(GlobalStatus.nodeReady.get()) {
+            return ResponseEntity.status(HttpStatus.OK).build();
+        } else {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+    }
+
+    @GetMapping("/liveness")
+    public ResponseEntity<Void> getLiveness() {
+        if(GlobalStatus.nodeLive.get()) {
+            return ResponseEntity.status(HttpStatus.OK).build();
+        } else {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
     }
 }

--- a/thorntail/kubernetes/deployment.yaml
+++ b/thorntail/kubernetes/deployment.yaml
@@ -26,7 +26,7 @@ spec:
             exec:
               command:
                 - curl
-                - localhost:8080/rest/health
+                - localhost:8080/rest/liveness
             initialDelaySeconds: 20
             periodSeconds: 10
             timeoutSeconds: 1
@@ -38,7 +38,7 @@ spec:
             exec:
               command:
                 - curl
-                - localhost:8080/rest/health
+                - localhost:8080/rest/readiness
             initialDelaySeconds: 10
             periodSeconds: 5
             timeoutSeconds: 1

--- a/thorntail/src/main/java/org/kie/hacep/endpoint/RestApplication.java
+++ b/thorntail/src/main/java/org/kie/hacep/endpoint/RestApplication.java
@@ -24,6 +24,8 @@ import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
+import org.kie.hacep.core.GlobalStatus;
+
 public class RestApplication extends Application {
 
     @Context
@@ -44,9 +46,24 @@ public class RestApplication extends Application {
 
     @GET
     @Produces("text/plain")
-    @Path("/health")
-    public Response getHealth() {
-        return Response.ok().build();
+    @Path("/readiness")
+    public Response getReadiness() {
+        if(GlobalStatus.nodeReady.get()) {
+            return Response.ok().build();
+        } else {
+            return Response.status(Response.Status.BAD_REQUEST).build();
+        }
+    }
+
+    @GET
+    @Produces("text/plain")
+    @Path("/liveness")
+    public Response getLiveness() {
+        if(GlobalStatus.nodeLive.get()) {
+            return Response.ok().build();
+        } else {
+            return Response.status(Response.Status.BAD_REQUEST).build();
+        }
     }
 }
 

--- a/thorntail/src/main/java/org/kie/hacep/endpoint/RestApplication.java
+++ b/thorntail/src/main/java/org/kie/hacep/endpoint/RestApplication.java
@@ -48,7 +48,7 @@ public class RestApplication extends Application {
     @Produces("text/plain")
     @Path("/readiness")
     public Response getReadiness() {
-        if(GlobalStatus.nodeReady.get()) {
+        if(GlobalStatus.nodeReady) {
             return Response.ok().build();
         } else {
             return Response.status(Response.Status.BAD_REQUEST).build();
@@ -59,7 +59,7 @@ public class RestApplication extends Application {
     @Produces("text/plain")
     @Path("/liveness")
     public Response getLiveness() {
-        if(GlobalStatus.nodeLive.get()) {
+        if(GlobalStatus.nodeLive) {
             return Response.ok().build();
         } else {
             return Response.status(Response.Status.BAD_REQUEST).build();


### PR DESCRIPTION
Readiness policy: end of bootstrap mechanism
Liveness policy: not live if invocation of a method on the session fails or not able to retrieve a snapshot (using a counter)

@desmax74 @mariofusco @jiripetrlik 