### PR TITLE
[DROOLS-5159] Allow Maven related scripts to run without creating a new user

### DIFF
--- a/jdkhttp/Dockerfile
+++ b/jdkhttp/Dockerfile
@@ -1,18 +1,8 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-RUN microdnf install java-1.8.0-openjdk-headless && microdnf install shadow-utils && microdnf clean all
-RUN groupadd -r app -g <id_group> && useradd -u <id_user> -r -g app -m -d /app -s /sbin/nologin -c "App user" app && chmod 755 /app
-WORKDIR /home/app/deployments
-USER app
+RUN microdnf install java-1.8.0-openjdk-headless && microdnf clean all
+COPY target/*-jdkhttp-fat.jar /app/app.jar
+COPY scripts /scripts
+RUN chmod 777 /app
 ENV HOME /app
-COPY target/*-jdkhttp-fat.jar /home/app/deployments/app.jar
-COPY ./scripts/logging.sh /home/app/deployments/logging.sh
-COPY ./scripts/maven.sh /home/app/deployments/maven.sh
-COPY ./scripts/start.sh /home/app/deployments/start.sh
-COPY ./scripts/jboss-settings.xml /app/.m2/settings.xml
-USER root
-RUN chmod 777 /home/app/deployments /app/.m2
-RUN chmod 666 /app/.m2/settings.xml
-RUN chmod 775 /home/app/deployments/logging.sh /home/app/deployments/maven.sh /home/app/deployments/start.sh /home/app/deployments/app.jar
-USER app
 EXPOSE 8080
-CMD ["bash", "/home/app/deployments/start.sh"]
+CMD ["bash", "/scripts/start.sh"]

--- a/jdkhttp/kubernetes/deployment.yaml
+++ b/jdkhttp/kubernetes/deployment.yaml
@@ -18,9 +18,6 @@ spec:
         version: v1
     spec:
       serviceAccountName: openshift-kie-jdkhttp
-      securityContext:
-        runAsUser: <id_user>
-        runAsNonRoot: true
       containers:
         - env:
           name: openshift-kie-jdkhttp

--- a/jdkhttp/scripts/maven.sh
+++ b/jdkhttp/scripts/maven.sh
@@ -1,5 +1,5 @@
 # common shell routines for use with maven
-source "/home/app/deployments/logging.sh"
+source "/app/scripts/logging.sh"
 
 # default settings.xml file
 __JBOSS_MAVEN_DEFAULT_SETTINGS_FILE="${HOME}/.m2/settings.xml"

--- a/jdkhttp/scripts/start.sh
+++ b/jdkhttp/scripts/start.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
+echo "---------Copy Maven Scripts to /app folder"
+mkdir /app/scripts
+cp /scripts/maven.sh /scripts/logging.sh /app/scripts
+chmod +x /app/scripts/maven.sh /app/scripts/logging.sh
+mkdir /app/.m2
+cp /scripts/jboss-settings.xml /app/.m2/settings.xml
 echo "---------Starting Maven Script---------"
-/home/app/deployments/maven.sh
+/app/scripts/maven.sh
 echo "---------End Maven Script---------"
 echo "---------Starting App---------"
-java -jar /home/app/deployments/app.jar
+java -Dkie.maven.settings.custom=/app/.m2/settings.xml -jar /app/app.jar

--- a/springboot/Dockerfile
+++ b/springboot/Dockerfile
@@ -1,18 +1,8 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-RUN microdnf install java-1.8.0-openjdk-headless && microdnf install shadow-utils && microdnf clean all
-RUN groupadd -r app -g <id_group> && useradd -u <id_user> -r -g app -m -d /app -s /sbin/nologin -c "App user" app && chmod 755 /app
-WORKDIR /home/app/deployments
-USER app
+RUN microdnf install java-1.8.0-openjdk-headless && microdnf clean all
+COPY target/*-springboot.jar /app/app.jar
+COPY scripts /scripts
+RUN chmod 777 /app
 ENV HOME /app
-COPY target/*-springboot.jar /home/app/deployments/app.jar
-COPY ./scripts/logging.sh /home/app/deployments/logging.sh
-COPY ./scripts/maven.sh /home/app/deployments/maven.sh
-COPY ./scripts/start.sh /home/app/deployments/start.sh
-COPY ./scripts/jboss-settings.xml /app/.m2/settings.xml
-USER root
-RUN chmod 777 /home/app/deployments /app/.m2
-RUN chmod 666 /app/.m2/settings.xml
-RUN chmod 775 /home/app/deployments/logging.sh /home/app/deployments/maven.sh /home/app/deployments/start.sh /home/app/deployments/app.jar
-USER app
 EXPOSE 8080
-CMD ["bash", "/home/app/deployments/start.sh"]
+CMD ["bash", "/scripts/start.sh"]

--- a/springboot/kubernetes/deployment.yaml
+++ b/springboot/kubernetes/deployment.yaml
@@ -18,9 +18,6 @@ spec:
         version: v1
     spec:
       serviceAccountName: openshift-kie-springboot
-      securityContext:
-        runAsUser: <id_user>
-        runAsNonRoot: true
       containers:
         - env:
           name: openshift-kie-springboot

--- a/springboot/scripts/maven.sh
+++ b/springboot/scripts/maven.sh
@@ -1,5 +1,5 @@
 # common shell routines for use with maven
-source "/home/app/deployments/logging.sh"
+source "/app/scripts/logging.sh"
 
 # default settings.xml file
 __JBOSS_MAVEN_DEFAULT_SETTINGS_FILE="${HOME}/.m2/settings.xml"

--- a/springboot/scripts/start.sh
+++ b/springboot/scripts/start.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
+echo "---------Copy Maven Scripts to /app folder"
+mkdir /app/scripts
+cp /scripts/maven.sh /scripts/logging.sh /app/scripts
+chmod +x /app/scripts/maven.sh /app/scripts/logging.sh
+mkdir /app/.m2
+cp /scripts/jboss-settings.xml /app/.m2/settings.xml
 echo "---------Starting Maven Script---------"
-/home/app/deployments/maven.sh
+/app/scripts/maven.sh
 echo "---------End Maven Script---------"
 echo "---------Starting App---------"
-java -jar /home/app/deployments/app.jar
+java -Dkie.maven.settings.custom=/app/.m2/settings.xml -jar /app/app.jar


### PR DESCRIPTION
@desmax74 @danielezonca 
This approach allows us to start Maven scripts without adding new user and without changing user ID according to Openshift project.